### PR TITLE
chore(frontend): add web manifest and PWA icons (192/512)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,7 +21,7 @@
     <!-- <link rel="icon" href="/favicon.svg" type="image/svg+xml" /> -->
     <!-- <link rel="icon" href="/favicon-16.png" sizes="16x16" /> -->
     <!-- <link rel="apple-touch-icon" href="/apple-touch-icon.png" /> -->
-    <!-- <link rel="manifest" href="/site.webmanifest" /> -->
+    <link rel="manifest" href="/frontend/public/site.webmanifest" />
 
     <!-- Social preview (add /public/og-image.png if you want previews) -->
     <meta property="og:title" content="Kyle Darden — Portfolio" />

--- a/frontend/public/site.webmanifest
+++ b/frontend/public/site.webmanifest
@@ -1,0 +1,13 @@
+{
+  "name": "Kyle Darden — Portfolio",
+  "short_name": "KD Portfolio",
+  "icons": [
+    { "src": "favicon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "favicon-512.png", "sizes": "512x512", "type": "image/png" }
+  ],
+  "theme_color": "#000000",
+  "background_color": "#000000",
+  "display": "standalone",
+  "start_url": ".",
+  "scope": "."
+}


### PR DESCRIPTION
Add a Web App Manifest and high-res PWA icons so the site “installs” cleanly on mobile/desktop (Add to Home Screen) and passes Lighthouse PWA checks. Keeps existing 16×16 / 32×32 favicons for browser tabs.