### PR TITLE
ci: add GitHub Actions workflow and README badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch: {}
+
+jobs:
+  backend:
+    name: Backend (Gradle)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: gradle
+      - uses: gradle/actions/setup-gradle@v3
+      - run: ./gradlew build --no-daemon
+
+  frontend:
+    name: Frontend (Node)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - run: npm run lint --if-present
+      - run: npm run typecheck --if-present
+      - run: npm run build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Deploy](https://github.com/dardenkyle/portfolio-site/actions/workflows/deploy-frontend.yml/badge.svg)](https://github.com/dardenkyle/portfolio-site/actions/workflows/deploy-frontend.yml)
-
+[![CI](https://github.com/dardenkyle/portfolio-site/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/dardenkyle/portfolio-site/actions/workflows/ci.yml)
 
 # Portfolio
 


### PR DESCRIPTION
## Summary
Introduce a CI pipeline for both backend and frontend, and add a README badge that reflects CI status.

## What's included
- `.github/workflows/ci.yml`
  - Triggers on `pull_request` to `main` and manual `workflow_dispatch`
  - **Backend job** (Gradle, Java 21): `./gradlew build --no-daemon`
  - **Frontend job** (Node 20): `npm ci`, optional `lint`/`typecheck`, then `npm run build`
  - Caching for Gradle and npm
  - Separate working directories: `backend/` and `frontend/`
- `README.md`
  - Adds CI status badge linking to this workflow

## Why
- Prevent broken builds from merging to `main`
- Visible build status for collaborators and recruiters
- Foundation for future gates (tests, lint rules, Lighthouse, etc.)

## How to test
1. Open this PR → CI should run both jobs and pass.
2. After merge, confirm the README badge renders and updates on subsequent PRs.
   - Badge URL format: `https://github.com/<OWNER>/<REPO>/actions/workflows/ci.yml/badge.svg?branch=main`
   - Replace `<OWNER>/<REPO>` if not already set.

## Follow-ups (optional)
- Require this workflow in branch protection for `main`
- Add `./gradlew test` (BE) and unit/e2e tests (FE)
- Add Prettier/ESLint checks and fail on warnings
- Add Lighthouse/Playwright smoke checks
- Add triggers for `staging` or feature branches if/when needed

## Risk / Rollback
- Low risk; CI only.
- Rollback by reverting this PR.