### PR TITLE
fix: add NonNull annotation to CorsRegistry parameter in CORS configuration

### DIFF
--- a/backend/src/main/java/com/kyledarden/backend/config/CorsConfig.java
+++ b/backend/src/main/java/com/kyledarden/backend/config/CorsConfig.java
@@ -2,13 +2,18 @@ package com.kyledarden.backend.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.lang.NonNull;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
 
 /**
  * Configures Cross-Origin Resource Sharing (CORS) for public API endpoints.
  * Allows the portfolio frontend to call the backend from approved origins only.
  */
+
+
+
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
 
@@ -20,7 +25,7 @@ public class CorsConfig implements WebMvcConfigurer {
      * Only GET/OPTIONS are allowed for now; no credentials.
      */
     @Override
-    public void addCorsMappings(CorsRegistry registry) {
+    public void addCorsMappings(@NonNull CorsRegistry registry) {
         registry.addMapping("/api/**")
                 .allowedOrigins(allowedOrigins.split("\\s*,\\s*"))
                 .allowedMethods("GET", "OPTIONS")


### PR DESCRIPTION
fix: add NonNull annotation to CorsRegistry parameter in CORS configuration to remove warning message