### PR TITLE
content: update home page copy and meta description

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
     <title>Kyle Darden — Portfolio</title>
     <meta
       name="description"
-      content="Kyle Darden — Data Engineer & backend systems builder. Live CS2 analytics platform, dbt data warehousing, and FastAPI services."
+      content="Kyle Darden — Data Engineer &amp; backend systems builder. Live CS2 analytics platform, dbt data warehousing, and FastAPI services."
     />
 
     <!-- Favicon(s) -->
@@ -27,7 +27,7 @@
     <meta property="og:title" content="Kyle Darden — Portfolio" />
     <meta
       property="og:description"
-      content="Kyle Darden — Data Engineer & backend systems builder. Live CS2 analytics platform, dbt data warehousing, and FastAPI services."
+      content="Kyle Darden — Data Engineer &amp; backend systems builder. Live CS2 analytics platform, dbt data warehousing, and FastAPI services."
     />
     <meta property="og:type" content="website" />
     <!-- <meta property="og:image" content="/og-image.png" /> -->

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
     <title>Kyle Darden — Portfolio</title>
     <meta
       name="description"
-      content="Backend-focused engineer. FreightFolio, CS2 Analytics, and more."
+      content="Kyle Darden — Data Engineer & backend systems builder. Live CS2 analytics platform, dbt data warehousing, and FastAPI services."
     />
 
     <!-- Favicon(s) -->
@@ -27,7 +27,7 @@
     <meta property="og:title" content="Kyle Darden — Portfolio" />
     <meta
       property="og:description"
-      content="Backend-focused engineer. FreightFolio, CS2 Analytics, and more."
+      content="Kyle Darden — Data Engineer & backend systems builder. Live CS2 analytics platform, dbt data warehousing, and FastAPI services."
     />
     <meta property="og:type" content="website" />
     <!-- <meta property="og:image" content="/og-image.png" /> -->

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -38,15 +38,13 @@ export default function Home() {
     <main className="max-w-6xl mx-auto px-6 py-12 space-y-14">
       {/* HERO */}
       <section className="mx-auto max-w-3xl text-center space-y-4">
-        <h1 className="text-4xl font-bold">
-          Kyle Darden — Backend-focused Engineer
-        </h1>
+        <h1 className="text-4xl font-bold">Kyle Darden — Data Engineer</h1>
         <p className="opacity-80">
-          Python • FastAPI • Postgres • Docker • AWS • CI/CD
+          Python • SQL • dbt • FastAPI • PostgreSQL • Docker
         </p>
         <p className="opacity-80">
-          Focused on building data-heavy, reliable backends and automation
-          pipelines.
+          I build data platforms end to end — ingestion, storage, and the APIs
+          that serve them, on a backend-engineering foundation.
         </p>
         <div className="flex items-center justify-center gap-3">
           <Button
@@ -92,15 +90,17 @@ export default function Home() {
         </header>
         <div className="bg-neutral-900/30 border border-neutral-800/50 rounded-xl p-6 shadow-lg">
           <p className="opacity-80 max-w-6xl mx-auto">
-            I’m a backend-focused engineer skilled in Python, FastAPI, and
-            PostgreSQL, with hands-on experience building data-heavy systems,
-            ETL pipelines, and automated CI/CD workflows. My background bridges
-            software engineering, QA automation, and data engineering — giving
-            me a strong edge in designing reliable, analytics-driven backends.{" "}
+            I build data platforms end to end. My CS2 Analytics project is live
+            and public — a Python ingestion pipeline feeding a PostgreSQL
+            store, a FastAPI service, and a React dashboard, deployed the whole
+            way through. I also build dimensional data warehouses (dbt,
+            star-schema modeling) and production backend services (FastAPI,
+            Postgres, Docker, AWS Cognito auth).{" "}
             <br />
             <br />
-            Currently open to Backend, QA Automation, Data Engineering, and Data
-            Science roles — Austin or remote.
+            B.S. in Physics from UT Austin; graduate training in data science
+            and machine learning; currently completing CS coursework towards
+            enrolling in a graduate program.
           </p>
         </div>
       </section>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -95,7 +95,7 @@ export default function Home() {
             store, a FastAPI service, and a React dashboard, deployed the whole
             way through. I also build dimensional data warehouses (dbt,
             star-schema modeling) and production backend services (FastAPI,
-            Postgres, Docker, AWS Cognito auth).{" "}
+            PostgreSQL, Docker, AWS Cognito auth).
             <br />
             <br />
             B.S. in Physics from UT Austin; graduate training in data science


### PR DESCRIPTION
## Summary

Repositions the home page from "Backend-focused Engineer" to **Data Engineer**, per the site update brief:

- **Hero heading:** "Kyle Darden — Data Engineer"
- **Hero tech line:** leads with the data stack — Python • SQL • dbt • FastAPI • PostgreSQL • Docker
- **Hero subhead:** "I build data platforms end to end — ingestion, storage, and the APIs that serve them, on a backend-engineering foundation."
- **About card:** rewritten around the live CS2 Analytics platform, dbt/star-schema warehousing, and backend services; education line now mentions current CS coursework towards enrolling in a graduate program
- **Meta + og description** (`frontend/index.html`): replaced with a prose sentence matching the new positioning

Copy-only change — no layout, theme, or animation changes.

Not included: repointing the Download Resume button at a Data Engineer resume — the new PDF isn't in `frontend/public/` yet, so the button still links the existing `Resume_KyleDarden_Backend_v1.1.pdf`.

Closes #50

## Test plan

- `npm run lint`, `npm run typecheck`, `npm run build` all pass
- Verified rendering locally via `npm run dev`