### PR TITLE
chore: add .github/labels.yml defining the repo label set

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,41 @@
+# Label set for dardenkyle/portfolio-site (see issue #59).
+# Source of truth for the repo's labels: name, color, description.
+
+# Area
+- name: frontend
+  color: "1d76db"
+  description: Vite + React frontend
+- name: backend
+  color: "0e8a16"
+  description: Spring Boot API
+- name: content
+  color: "fbca04"
+  description: Projects, skills, page copy, case studies
+- name: analytics
+  color: "5319e7"
+  description: GA4 events and tracking
+- name: docs
+  color: "006b75"
+  description: README, ADRs, docs/
+- name: ci/deploy
+  color: "c5def5"
+  description: Workflows, GitHub Pages, build tooling
+
+# Type
+- name: bug
+  color: "d73a4a"
+  description: Something isn't working
+- name: enhancement
+  color: "a2eeef"
+  description: New feature or request
+- name: documentation
+  color: "0075ca"
+  description: Improvements or additions to documentation
+- name: question
+  color: "d876e3"
+  description: Further information is requested
+
+# Meta
+- name: chore
+  color: "ededed"
+  description: Maintenance with no user-facing change


### PR DESCRIPTION
Adds `.github/labels.yml` declaring the label set proposed in #59 — area labels (`frontend`, `backend`, `content`, `analytics`, `docs`, `ci/deploy`), the kept default type labels (`bug`, `enhancement`, `documentation`, `question`), and `chore` — each with a color and description, so the label set is versioned in the repo.

This PR only adds the definition file; it does not create the labels on GitHub or change any workflows. Applying the file (manually via `gh label create --force`, or later via a sync action) can be done as a follow-up.

Refs #59

## Notes for review

- `docs` and `documentation` both appear because the issue lists them separately (area vs. type); happy to drop one if that feels redundant.
- Colors for new labels are proposals — easy to tweak in this file.