### PR TITLE
content: consistency sweep for tech lists and external links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,10 @@ backend service classes** — see "Where Content Lives" below.
 
 ### Frontend (run from `frontend/`)
 
-- `npm install` — install deps (required after fresh clone)
+- `npm ci` — install deps (required after fresh clone or in a new worktree).
+  Always use `npm ci`, not `npm install`, so `package-lock.json` is never
+  rewritten as a side effect; `npm install` is only for intentionally adding
+  or upgrading dependencies.
 - `npm run dev` — dev server at http://localhost:5173
 - `npm run typecheck` — TypeScript check (`tsc -b`)
 - `npm run lint` — ESLint

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Backend will be available at `http://localhost:8080`
 
 ```
 cd frontend
-npm install
+npm ci
 npm run dev
 ```
 
@@ -132,7 +132,7 @@ frontend/
 ## Contact
 
 - Email: [darden_kyle@hotmail.com](mailto:darden_kyle@hotmail.com)
-- LinkedIn: [linkedin.com/in/kyle-darden](https://www.linkedin.com/in/kyle-darden)
+- LinkedIn: [linkedin.com/in/kyle-darden](https://www.linkedin.com/in/kyle-darden/)
 - GitHub: [github.com/dardenkyle](https://github.com/dardenkyle)
 
 ## License

--- a/backend/src/main/java/com/kyledarden/backend/service/ProjectService.java
+++ b/backend/src/main/java/com/kyledarden/backend/service/ProjectService.java
@@ -91,7 +91,7 @@ public class ProjectService {
                     "Queue-based backend that scrapes and normalizes CS2 match data into a queryable Postgres schema.",
                     List.of("Gaming Analytics", "Data Pipeline", "Web Scraping", "API Development", "Automation"),
                     "https://github.com/dardenkyle/CS2-analytics",
-                    null,
+                    "https://dardenkyle.github.io/CS2-analytics/",
                     30,
                     OffsetDateTime.parse("2025-06-30T00:00:00Z"),
                     null,

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,7 +21,7 @@
     <!-- <link rel="icon" href="/favicon.svg" type="image/svg+xml" /> -->
     <!-- <link rel="icon" href="/favicon-16.png" sizes="16x16" /> -->
     <!-- <link rel="apple-touch-icon" href="/apple-touch-icon.png" /> -->
-    <link rel="manifest" href="/frontend/public/site.webmanifest" />
+    <link rel="manifest" href="/site.webmanifest" />
 
     <!-- Social preview (add /public/og-image.png if you want previews) -->
     <meta property="og:title" content="Kyle Darden — Portfolio" />

--- a/frontend/src/pages/Contact.tsx
+++ b/frontend/src/pages/Contact.tsx
@@ -81,8 +81,8 @@ export default function Contact() {
 
             {/* Tagline */}
             <p className="text-slate-300">
-              Backend-focused engineer passionate about building scalable,
-              efficient systems and learning cutting-edge technologies.
+              I build data platforms end to end — ingestion, storage, and the
+              APIs that serve them, on a backend-engineering foundation.
             </p>
 
             {/* Contact Methods */}
@@ -101,6 +101,8 @@ export default function Contact() {
                 <a
                   className="text-white hover:text-blue-400 transition-colors"
                   href="https://www.linkedin.com/in/kyle-darden/"
+                  target="_blank"
+                  rel="noopener noreferrer"
                 >
                   kyle-darden
                 </a>
@@ -111,6 +113,8 @@ export default function Contact() {
                 <a
                   className="text-white hover:text-blue-400 transition-colors"
                   href="https://github.com/dardenkyle"
+                  target="_blank"
+                  rel="noopener noreferrer"
                 >
                   dardenkyle
                 </a>

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -41,9 +41,10 @@ export default function Projects() {
         <section className="mx-auto max-w-3xl text-center space-y-4">
           <h1 className="text-4xl font-bold">Projects</h1>
           <p className="opacity-80">
-            A selection of my work, showcasing backend engineering with Python,
-            FastAPI, and PostgreSQL. These projects highlight my skills in API
-            design, data workflows, and system reliability.
+            A selection of my work — data pipelines, warehouses, and backend
+            services built with Python, SQL, dbt, FastAPI, PostgreSQL, and
+            Docker. These projects highlight my skills in data workflows, API
+            design, and system reliability.
           </p>
         </section>
         <ProjectsGrid projects={projects} />

--- a/frontend/src/ui/Nav.tsx
+++ b/frontend/src/ui/Nav.tsx
@@ -99,7 +99,7 @@ export default function Nav() {
             <img src="/github.png" alt="GitHub" className="w-5 h-5" />
           </a>
           <a
-            href="https://linkedin.com/in/kyle-darden"
+            href="https://www.linkedin.com/in/kyle-darden/"
             target="_blank"
             rel="noopener noreferrer"
             className={`p-2 rounded transition-all duration-300 ${getGlowClass(
@@ -109,7 +109,7 @@ export default function Nav() {
             onMouseLeave={handleMouseLeave}
             onClick={() =>
               handleExternalLinkClick(
-                "https://linkedin.com/in/kyle-darden",
+                "https://www.linkedin.com/in/kyle-darden/",
                 "LinkedIn"
               )
             }


### PR DESCRIPTION
## Summary

Final consistency pass after the page-level content updates: every LinkedIn link now uses the same canonical URL, the Contact tagline and Projects intro match the Home/About copy and hero tech list, and the CS2 Analytics project now links to its live demo (the copy already described it as live, but nothing linked to it). Also switches documented dependency setup from `npm install` to `npm ci` to stop unintended `package-lock.json` rewrites during routine verification.

## Related Issue

Closes #55

## Scope

- `frontend/src/ui/Nav.tsx`, `frontend/src/pages/Contact.tsx`, `README.md` - LinkedIn links normalized to `https://www.linkedin.com/in/kyle-darden/`
- `frontend/src/pages/Contact.tsx` - tagline aligned with Home/About; external links open in a new tab to match Nav
- `frontend/src/pages/Projects.tsx` - intro updated to name the same six technologies as the Home hero (Python, SQL, dbt, FastAPI, PostgreSQL, Docker)
- `backend/.../service/ProjectService.java` - CS2 Analytics `liveUrl` set to `https://dardenkyle.github.io/CS2-analytics/`
- `frontend/index.html` - web manifest path fixed (`/frontend/public/site.webmanifest` -> `/site.webmanifest`)
- `README.md`, `CLAUDE.md` - dependency setup instructions changed to `npm ci`

## Out of Scope

- Skills content and ordering (#53) and resume PDF update (#54); if those change tech lists or links, this sweep may need a small follow-up pass
- Any copy changes beyond consistency alignment

## Risk Level

Risk level: Low

Reason: Content strings and docs only. The single backend change fills an existing nullable field (`liveUrl`) that the frontend already renders; no logic, routes, or response shapes change.

## Architecture Check

- [x] Controllers stay thin; services own the data.
- [x] Frontend keeps the API-types → mappers → domain-model layering; new fields added in all three layers.
- [x] No API route or response shape changes unless explicitly requested.
- [x] No changes to CORS config, deploy workflows, or secrets usage unless explicitly requested.
- [x] No analytics event names/parameters changed unless explicitly requested.
- [x] No new dependencies or build tooling changes unless explicitly requested.

## Documentation Check

Documentation: Updated

Reason: README contact link corrected and setup steps switched to `npm ci`; CLAUDE.md frontend commands updated to prescribe `npm ci` and reserve `npm install` for intentional dependency changes.

## Verification

Commands run:

- `npm ci`, `npm run lint`, `npm run typecheck`, `npm run build` (frontend)
- `curl -s -o /dev/null -w "%{http_code}" https://dardenkyle.github.io/CS2-analytics/`
- `git status` after `npm ci`

Results:

- Lint, typecheck, and build all pass; `package-lock.json` untouched after install
- Live demo URL returns HTTP 200
- Backend Gradle build not run locally (no JDK on this machine); the one-line change is covered by CI's Gradle build

## Review Notes

- The `index.html` manifest path fix is a drive-by correctness fix spotted during the sweep; the old path does not exist in the built site
- The `npm ci` docs change is included here per discussion because the lockfile churn surfaced while working this issue