### PR TITLE
content: add site-sentry project and Playwright skill

### DIFF
--- a/backend/src/main/java/com/kyledarden/backend/service/ProjectService.java
+++ b/backend/src/main/java/com/kyledarden/backend/service/ProjectService.java
@@ -408,7 +408,7 @@ public class ProjectService {
                                     "Containerized the suite with Docker so the same image runs locally and in CI, and managed dependencies with Poetry with pinned Playwright browser installs.",
                                     "The suite behaves the same everywhere it runs, from a laptop to the scheduled CI workflow.",
                                     List.of(),
-                                    List.of("Docker", "Python", "DevX"),
+                                    List.of("Docker", "Python", "devx"),
                                     2))));
 
     public List<Project> all() {

--- a/backend/src/main/java/com/kyledarden/backend/service/ProjectService.java
+++ b/backend/src/main/java/com/kyledarden/backend/service/ProjectService.java
@@ -363,7 +363,53 @@ public class ProjectService {
                                     "Delivered a clean dimensional warehouse powering downstream analytics and dashboards with minimal join complexity and intuitive naming conventions.",
                                     List.of(),
                                     List.of("dbt", "PostgreSQL", "Data Modeling", "Analytics"),
-                                    3))));
+                                    3))),
+
+            new ProjectTemplate(
+                    "site-sentry",
+                    "Site Sentry (QA Automation)",
+                    "Automated QA suite for kyledarden.com - Playwright + Pytest browser tests running twice daily via GitHub Actions, with HTML reports and Docker support.",
+                    List.of("QA Automation", "Testing", "CI/CD", "Monitoring"),
+                    "https://github.com/dardenkyle/site-sentry",
+                    null,
+                    50,
+                    OffsetDateTime.parse("2025-10-15T00:00:00Z"),
+                    null,
+                    null,
+
+                    /* overview */
+                    "site-sentry is an automated QA suite that continuously verifies kyledarden.com. Playwright drives real-browser smoke, navigation, and UI tests orchestrated with Pytest, and a scheduled GitHub Actions workflow runs the suite twice daily. Failures produce HTML reports with screenshots, and the suite runs locally or in Docker for consistent environments.",
+
+                    /* techStack - using references to TechService */
+                    List.of(
+                            new Project.TechReference("python", 1),
+                            new Project.TechReference("playwright", 2),
+                            new Project.TechReference("pytest", 3),
+                            new Project.TechReference("docker", 4),
+                            new Project.TechReference("github-actions", 5),
+                            new Project.TechReference("git", 6)),
+
+                    /* challenges */
+                    List.of(
+                            new Project.Challenge(
+                                    "scheduled-browser-tests-in-ci",
+                                    "Running browser tests unattended on a schedule",
+                                    "Real-browser tests had to run twice a day in CI without anyone watching, so failures needed to be diagnosable after the fact rather than reproduced live.",
+                                    "Built a scheduled GitHub Actions workflow around Playwright with Pytest as the runner, generating HTML reports and capturing screenshots automatically on failure. Kept the suite fast so scheduled runs give quick feedback.",
+                                    "Twice-daily automated runs complete in about two and a half minutes, with report artifacts that make failures reviewable without rerunning.",
+                                    List.of(),
+                                    List.of("Playwright", "Pytest", "GitHub Actions", "CI/CD"),
+                                    1),
+
+                            new Project.Challenge(
+                                    "consistent-test-environments",
+                                    "Keeping local and CI test environments identical",
+                                    "Browser automation is sensitive to environment drift - browser versions, dependencies, and OS differences can make tests pass locally and fail in CI.",
+                                    "Containerized the suite with Docker so the same image runs locally and in CI, and managed dependencies with Poetry with pinned Playwright browser installs.",
+                                    "The suite behaves the same everywhere it runs, from a laptop to the scheduled CI workflow.",
+                                    List.of(),
+                                    List.of("Docker", "Python", "DevX"),
+                                    2))));
 
     public List<Project> all() {
         return projectTemplates.stream()

--- a/backend/src/main/java/com/kyledarden/backend/service/TechService.java
+++ b/backend/src/main/java/com/kyledarden/backend/service/TechService.java
@@ -130,6 +130,11 @@ public class TechService {
                                         YearMonth.of(2024, 3),
                                         new ArrayList<>()),
 
+                        new TechItem("Playwright", "DevOps & Tools", "playwright",
+                                        "I use Playwright for real-browser automation in my QA work. It drives site-sentry's smoke, navigation, and UI checks against kyledarden.com on a twice-daily schedule.",
+                                        YearMonth.of(2025, 10),
+                                        new ArrayList<>()),
+
                         new TechItem("Postman", "DevOps & Tools", "postman",
                                         "I use Postman to test, document, and automate RESTful API requests and workflows during backend and data service development.",
                                         YearMonth.of(2024, 2),


### PR DESCRIPTION
## Summary

Adds site-sentry as the fifth project on the Projects page and a supporting Playwright skill entry. site-sentry is the Playwright + Pytest QA suite that runs against kyledarden.com twice daily via a scheduled GitHub Actions workflow. All content is grounded in the public repo's README.

## Related Issue

Closes #67

## Scope

- `backend/.../service/ProjectService.java` - new site-sentry project template (summary, tags, overview, tech stack, two challenges), ordered last (order 50)
- `backend/.../service/TechService.java` - new Playwright tech item (DevOps & Tools, placed next to Pytest)

## Out of Scope

- FreightFolio description alignment (#68 / PR #69, separate branch)
- Case study for site-sentry (can be added later if wanted)

## Risk Level

Risk level: Low

Reason: Additive content only - one new project template and one new tech item; no existing entries, routes, or response shapes changed. The new tech references resolve against the new tech item.

## Architecture Check

- [x] Controllers stay thin; services own the data.
- [x] Frontend keeps the API-types → mappers → domain-model layering; new fields added in all three layers.
- [x] No API route or response shape changes unless explicitly requested.
- [x] No changes to CORS config, deploy workflows, or secrets usage unless explicitly requested.
- [x] No analytics event names/parameters changed unless explicitly requested.
- [x] No new dependencies or build tooling changes unless explicitly requested.

## Documentation Check

Documentation: Update not needed

Reason: Content data addition in the locations CLAUDE.md already documents; no commands, endpoints, or architecture changes. No case study added, so no case-study config change.

## Verification

Commands run:

- `./gradlew build` (backend build + tests)
- Ran backend (`bootRun`) and frontend (`npm run dev`) locally; loaded `/projects`, `/projects/site-sentry`, `/skills`, and `/skills/playwright` in a browser; checked `/api/projects` and `/api/skills/playwright`

Results:

- Build and tests pass
- site-sentry appears last in the projects list; its detail page renders overview, six-item tech stack, both challenges, and the GitHub link; Playwright shows under DevOps & Tools and links back to the project

## Review Notes

- Project facts (twice-daily schedule, HTML reports with screenshots, Docker support, ~2m30s CI runs) come from the site-sentry README so every claim is verifiable from the linked repo.
