### PR TITLE
content: add SQL to the home page tech stack

### DIFF
--- a/frontend/src/utils/techStack.ts
+++ b/frontend/src/utils/techStack.ts
@@ -6,6 +6,7 @@ export interface TechItem {
 
 export const TECH_STACK: TechItem[] = [
   { name: "Python", category: "Language", slug: "python" },
+  { name: "SQL", category: "Language", slug: "sql" },
   { name: "Java", category: "Language", slug: "java" },
   { name: "TypeScript", category: "Language", slug: "typescript" },
   { name: "FastAPI", category: "Backend", slug: "fastapi" },
@@ -16,5 +17,4 @@ export const TECH_STACK: TechItem[] = [
   { name: "AWS", category: "Cloud", slug: "aws" },
   { name: "dbt", category: "Data", slug: "dbt" },
   { name: "GitHub Actions", category: "CI/CD", slug: "github-actions" },
-  { name: "Tailwind CSS", category: "Styling", slug: "tailwind-css" },
 ];


### PR DESCRIPTION
## Summary

Adds SQL to the home page tech stack grid, ordered next to Python, so the grid reflects the data stack. Removes Tailwind CSS to keep the grid at 12 items for layout symmetry (2x6 desktop, 3x4 tablet); Tailwind remains on the Skills page.

## Related Issue

Closes #71

## Scope

- `frontend/src/utils/techStack.ts` - one entry added (SQL), one removed (Tailwind CSS)

## Out of Scope

- The Skills page and backend skill data (unchanged)
- Any other home page content

## Risk Level

Risk level: Low

Reason: One-line data change in a hardcoded frontend list; the SQL entry links to an existing skill slug, and the grid item count is unchanged.

## Architecture Check

- [x] Controllers stay thin; services own the data.
- [x] Frontend keeps the API-types → mappers → domain-model layering; new fields added in all three layers.
- [x] No API route or response shape changes unless explicitly requested.
- [x] No changes to CORS config, deploy workflows, or secrets usage unless explicitly requested.
- [x] No analytics event names/parameters changed unless explicitly requested.
- [x] No new dependencies or build tooling changes unless explicitly requested.

## Documentation Check

Documentation: Update not needed

Reason: Content-only change to a hardcoded display list; no commands, endpoints, content locations, or architecture affected.

## Verification

Commands run:

- `npm run lint`, `npm run typecheck`, `npm run build`
- Ran backend and frontend locally and loaded the home page in a browser

Results:

- All checks pass
- Grid renders 2x6 with SQL second (after Python); SQL tile links to the existing `/skills/sql` page

## Review Notes

- Tailwind CSS was chosen as the item to remove because it is the lowest-signal entry for the site's data engineering positioning and still appears on the Skills page.
