### PR TITLE
content: remove stale free-tier note from CS2 Analytics case study

### DIFF
--- a/frontend/public/case-studies/cs2-analytics.md
+++ b/frontend/public/case-studies/cs2-analytics.md
@@ -70,4 +70,4 @@ CS2 Analytics demonstrates how I approach backend and data engineering challenge
 
 **[View Source Code](https://github.com/dardenkyle/CS2-analytics)** - Complete implementation with documentation
 
-**[Live Demo](https://dardenkyle.github.io/CS2-analytics/)** - Public dashboard served live from the production database (the free-tier API can take ~30 seconds to wake after idle periods)
+**[Live Demo](https://dardenkyle.github.io/CS2-analytics/)** - Public dashboard served live from the production database


### PR DESCRIPTION
## Summary

Removes the stale free-tier note from the CS2 Analytics case study. The API now runs on paid hosting and responds immediately, so the "~30 seconds to wake after idle" parenthetical on the Live Demo link is no longer accurate.

## Related Issue

Closes #77

## Scope

- `frontend/public/case-studies/cs2-analytics.md` - one line (Live Demo link) edited

## Out of Scope

- Other pending CS2 content work (#73: tech stack additions)
- Other case study updates (#74, #75)

## Risk Level

Risk level: Low

Reason: One-line edit to a static markdown asset; no code paths affected.

## Architecture Check

- [x] Controllers stay thin; services own the data.
- [x] Frontend keeps the API-types → mappers → domain-model layering; new fields added in all three layers.
- [x] No API route or response shape changes unless explicitly requested.
- [x] No changes to CORS config, deploy workflows, or secrets usage unless explicitly requested.
- [x] No analytics event names/parameters changed unless explicitly requested.
- [x] No new dependencies or build tooling changes unless explicitly requested.

## Documentation Check

Documentation: Updated

Reason: This change is itself a case study update, keeping it accurate per the documentation expectations in CLAUDE.md.

## Verification

Commands run:

- Reviewed the edited line in context

Results:

- The Live Demo line now reads "Public dashboard served live from the production database" with no hosting caveat

## Review Notes

- Spotted while editing (not changed here): the case study's closing paragraph says "how I'd contribute as a Backend or Data Engineer" - leading with Backend. May be worth flipping to lead with Data Engineer in a future content pass.
