### PR TITLE
chore: add priority and risk labels to labels.yml

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -39,3 +39,25 @@
 - name: chore
   color: "ededed"
   description: Maintenance with no user-facing change
+
+# Priority
+- name: "priority: high"
+  color: "d93f0b"
+  description: Address before other queued work
+- name: "priority: medium"
+  color: "fbca04"
+  description: Normal queue order
+- name: "priority: low"
+  color: "c2e0c6"
+  description: Nice to have; no urgency
+
+# Risk (matches the PR template's risk levels)
+- name: "risk: high"
+  color: "b60205"
+  description: High blast radius; review carefully
+- name: "risk: medium"
+  color: "f9d0c4"
+  description: Moderate blast radius
+- name: "risk: low"
+  color: "bfe5bf"
+  description: Contained change; low blast radius


### PR DESCRIPTION
## Summary

Adds priority (high/medium/low) and risk (high/medium/low) label groups to `.github/labels.yml`, the declared source of truth for the repo's labels. The matching labels were already created on GitHub and applied to open issues and PRs; this keeps the file accurate.

## Related Issue

Closes # (no issue; direct request)

## Scope

- `.github/labels.yml` - two new label groups appended (Priority, Risk)

## Out of Scope

- Label assignments on issues/PRs (done directly via the API)
- Any automation that syncs labels.yml to GitHub

## Risk Level

Risk level: Low

Reason: Documentation-style config file only; nothing consumes it programmatically.

## Architecture Check

- [x] Controllers stay thin; services own the data.
- [x] Frontend keeps the API-types → mappers → domain-model layering; new fields added in all three layers.
- [x] No API route or response shape changes unless explicitly requested.
- [x] No changes to CORS config, deploy workflows, or secrets usage unless explicitly requested.
- [x] No analytics event names/parameters changed unless explicitly requested.
- [x] No new dependencies or build tooling changes unless explicitly requested.

## Documentation Check

Documentation: Updated

Reason: This change is itself the documentation update - labels.yml is the label set's source of truth.

## Verification

Commands run:

- `gh-axi label list` after creating the labels on GitHub

Results:

- All six new labels exist on GitHub with colors/descriptions matching this file

## Review Notes

- Risk label names mirror the PR template's risk levels (Low/Medium/High) so PRs can carry their declared risk as a label.
