### PR TITLE
content: add SQL and Vite to the CS2 Analytics tech stack

### DIFF
--- a/backend/src/main/java/com/kyledarden/backend/service/ProjectService.java
+++ b/backend/src/main/java/com/kyledarden/backend/service/ProjectService.java
@@ -103,16 +103,18 @@ public class ProjectService {
                     /* techStack - now using references to TechService */
                     List.of(
                             new Project.TechReference("python", 1),
-                            new Project.TechReference("fastapi", 2),
-                            new Project.TechReference("postgresql", 3),
-                            new Project.TechReference("sqlalchemy", 4),
-                            new Project.TechReference("beautifulsoup", 5),
-                            new Project.TechReference("react", 6),
-                            new Project.TechReference("typescript", 7),
-                            new Project.TechReference("docker", 8),
-                            new Project.TechReference("github-actions", 9),
-                            new Project.TechReference("pytest", 10),
-                            new Project.TechReference("git", 11)),
+                            new Project.TechReference("sql", 2),
+                            new Project.TechReference("fastapi", 3),
+                            new Project.TechReference("postgresql", 4),
+                            new Project.TechReference("sqlalchemy", 5),
+                            new Project.TechReference("beautifulsoup", 6),
+                            new Project.TechReference("react", 7),
+                            new Project.TechReference("typescript", 8),
+                            new Project.TechReference("vite", 9),
+                            new Project.TechReference("docker", 10),
+                            new Project.TechReference("github-actions", 11),
+                            new Project.TechReference("pytest", 12),
+                            new Project.TechReference("git", 13)),
 
                     /* challenges */
                     List.of(


### PR DESCRIPTION
## Summary

Adds SQL and Vite to the CS2 Analytics project's tech stack. Both are demonstrated in the public repo (`cs2_analytics/storage/schema.sql` plus raw queries in the player service; `frontend/vite.config.ts`) but were missing from the project's listed stack. This also links the SQL and Vite skill cards to the flagship project.

## Related Issue

Closes #73

## Scope

- `backend/.../service/ProjectService.java` - two tech references added to the cs2-analytics template; following references renumbered

## Out of Scope

- CS2 case study (its Stack section already lists Vite; SQL is implicit via the schema/queries described there)
- Other projects' tech stacks

## Risk Level

Risk level: Low

Reason: Additive references to existing tech items; resolution verified by the build and both slugs already exist in TechService.

## Architecture Check

- [x] Controllers stay thin; services own the data.
- [x] Frontend keeps the API-types → mappers → domain-model layering; new fields added in all three layers.
- [x] No API route or response shape changes unless explicitly requested.
- [x] No changes to CORS config, deploy workflows, or secrets usage unless explicitly requested.
- [x] No analytics event names/parameters changed unless explicitly requested.
- [x] No new dependencies or build tooling changes unless explicitly requested.

## Documentation Check

Documentation: Update not needed

Reason: Content data change in a documented content location; the CS2 case study already reflects both technologies.

## Verification

Commands run:

- `./gradlew build` (backend build + tests)

Results:

- Build and tests pass; both new references resolve against existing TechService slugs (`sql`, `vite`)

## Review Notes

- SQL is ordered right after Python and Vite after TypeScript, matching how the other projects order their stacks.
