### PR TITLE
fix: contact form silently dropped every message

### DIFF
--- a/frontend/src/pages/Contact.tsx
+++ b/frontend/src/pages/Contact.tsx
@@ -54,9 +54,11 @@ export default function Contact() {
     try {
       // FormSubmit only processes programmatic (fetch) posts on its
       // /ajax/ endpoint; the plain endpoint answers them with 200 +
-      // homepage HTML and silently drops the submission (issue #82)
+      // homepage HTML and silently drops the submission (issue #82).
+      // The path segment is FormSubmit's random-string alias for the
+      // destination address, keeping the email out of the bundle.
       const response = await fetch(
-        "https://formsubmit.co/ajax/darden_kyle@hotmail.com",
+        "https://formsubmit.co/ajax/af29b69af1f12fb2889f3bb3d41b2376",
         {
           method: "POST",
           headers: { Accept: "application/json" },

--- a/frontend/src/pages/Contact.tsx
+++ b/frontend/src/pages/Contact.tsx
@@ -52,11 +52,27 @@ export default function Contact() {
     }
 
     try {
-      // Submit to FormSubmit
-      await fetch("https://formsubmit.co/darden_kyle@hotmail.com", {
-        method: "POST",
-        body: formData,
-      });
+      // FormSubmit only processes programmatic (fetch) posts on its
+      // /ajax/ endpoint; the plain endpoint answers them with 200 +
+      // homepage HTML and silently drops the submission (issue #82)
+      const response = await fetch(
+        "https://formsubmit.co/ajax/darden_kyle@hotmail.com",
+        {
+          method: "POST",
+          headers: { Accept: "application/json" },
+          body: formData,
+        }
+      );
+
+      // FormSubmit reports failures as 200 + {"success": "false"}, so
+      // the body is the only reliable signal
+      const result = (await response.json()) as {
+        success?: string;
+        message?: string;
+      };
+      if (!response.ok || result.success !== "true") {
+        throw new Error(result.message || `HTTP ${response.status}`);
+      }
 
       setShowSuccess(true);
       form.reset();


### PR DESCRIPTION
Closes #82.

## Root cause

Two independent problems compounded into silent data loss:

1. **Wrong endpoint for programmatic posts.** The form posted `FormData` via `fetch` to `https://formsubmit.co/<email>`. That endpoint only processes real browser form navigations - a `fetch` POST gets HTTP 200 with FormSubmit's marketing homepage and the submission is dropped. FormSubmit's documented endpoint for AJAX/fetch submissions is `/ajax/<email>`. (This previously worked, so FormSubmit changed behavior on their side.)
2. **The response was never inspected.** `handleSubmit` awaited the fetch and unconditionally showed "Message sent successfully!". Any failure short of a network error - including the above - rendered as success.

## Fix

- Post to `https://formsubmit.co/ajax/<random-string-alias>` (FormSubmit resolves the alias to the destination address server-side, keeping the email out of the bundle) with `Accept: application/json`.
- Gate success on the response body: FormSubmit reports failures as **HTTP 200** with `{"success": "false", "message": ...}`, so `response.ok` alone is not a signal. Anything other than `success: "true"` throws into the existing error state.

## Verification (E2E)

- Reproduced on the live site: instrumented `fetch`, real submission -> 200 + homepage HTML, success banner shown, nothing delivered.
- Same payload against `/ajax/` -> `{"success":"true","message":"The form was submitted successfully."}` and the email arrives (the address is still activated).
- Fixed form on the dev server: real submission -> ajax endpoint, `success: "true"`, success banner.
- Failure path: mocked a 200/`success:"false"` response (the exact shape that used to masquerade as success) -> error message shown, no success banner.

## Follow-up worth filing

site-sentry runs twice daily and never caught this - a contact-form check (assert the `/ajax/` endpoint answers `success: "true"` for a test payload, or at minimum that the form wiring targets the ajax endpoint) would guard the portfolio's single conversion path.
