### PR TITLE
seo: build-time sitemap.xml derived from prerendered output

### DIFF
--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Allow: /
+
+Sitemap: https://kyledarden.com/sitemap.xml

--- a/frontend/react-router.config.ts
+++ b/frontend/react-router.config.ts
@@ -1,6 +1,42 @@
+import { readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
 import type { Config } from "@react-router/dev/config";
 import { loadEnv } from "vite";
 import { PROJECTS_WITH_CASE_STUDIES } from "./src/config/caseStudies";
+
+// Canonical origin for sitemap URLs (mirrors frontend/public/CNAME)
+const SITE_ORIGIN = "https://kyledarden.com";
+
+// The prerendered output is the source of truth: every route the build
+// emitted is a <dir>/index.html under the client directory. (The config
+// module is instantiated separately for prerender() and buildEnd(), so
+// the route list cannot simply be shared between them.)
+async function prerenderedRoutePaths(clientDir: string): Promise<string[]> {
+  const entries = await readdir(clientDir, { recursive: true });
+  return entries
+    .filter((entry) => path.basename(entry) === "index.html")
+    .map((entry) => path.dirname(entry))
+    .map((dir) => (dir === "." ? "/" : `/${dir.split(path.sep).join("/")}`))
+    .sort();
+}
+
+// GitHub Pages 301s directory paths without a trailing slash, so the
+// sitemap lists the canonical trailing-slash form crawlers get a 200
+// from; /404 is the error page and must not be indexed
+function sitemapXml(paths: string[]): string {
+  const urls = paths
+    .filter((p) => p !== "/404")
+    .map((p) => `${SITE_ORIGIN}${p === "/" ? "/" : `${p}/`}`)
+    .map((loc) => `  <url><loc>${loc}</loc></url>`)
+    .join("\n");
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    urls,
+    "</urlset>",
+    "",
+  ].join("\n");
+}
 
 // The config runs in Node outside Vite's transform pipeline, so
 // import.meta.env is not populated here; resolve VITE_API_URL the same
@@ -23,7 +59,7 @@ async function fetchSlugs(url: string): Promise<string[]> {
   return items.map((item) => item.slug);
 }
 
-export default {
+const config: Config = {
   // Static site: no server runtime, GitHub Pages serves the build output
   ssr: false,
   // Keep the existing src/ layout instead of the default app/ directory
@@ -55,4 +91,17 @@ export default {
       ...skillSlugs.map((slug) => `/skills/${slug}`),
     ];
   },
-} satisfies Config;
+  // Emit the sitemap from the routes the build actually prerendered
+  async buildEnd({ reactRouterConfig }) {
+    const clientDir = path.join(reactRouterConfig.buildDirectory, "client");
+    const routePaths = await prerenderedRoutePaths(clientDir);
+    if (routePaths.length === 0) {
+      throw new Error(`Sitemap: no prerendered routes found in ${clientDir}`);
+    }
+    const sitemapPath = path.join(clientDir, "sitemap.xml");
+    await writeFile(sitemapPath, sitemapXml(routePaths), "utf-8");
+    console.log(`Sitemap: ${routePaths.length - 1} URLs -> ${sitemapPath}`);
+  },
+};
+
+export default config;

--- a/frontend/react-router.config.ts
+++ b/frontend/react-router.config.ts
@@ -21,11 +21,9 @@ async function prerenderedRoutePaths(clientDir: string): Promise<string[]> {
 }
 
 // GitHub Pages 301s directory paths without a trailing slash, so the
-// sitemap lists the canonical trailing-slash form crawlers get a 200
-// from; /404 is the error page and must not be indexed
+// sitemap lists the canonical trailing-slash form crawlers get a 200 from
 function sitemapXml(paths: string[]): string {
   const urls = paths
-    .filter((p) => p !== "/404")
     .map((p) => `${SITE_ORIGIN}${p === "/" ? "/" : `${p}/`}`)
     .map((loc) => `  <url><loc>${loc}</loc></url>`)
     .join("\n");
@@ -98,9 +96,11 @@ const config: Config = {
     if (routePaths.length === 0) {
       throw new Error(`Sitemap: no prerendered routes found in ${clientDir}`);
     }
+    // /404 is the error page and must not be indexed
+    const sitemapPaths = routePaths.filter((p) => p !== "/404");
     const sitemapPath = path.join(clientDir, "sitemap.xml");
-    await writeFile(sitemapPath, sitemapXml(routePaths), "utf-8");
-    console.log(`Sitemap: ${routePaths.length - 1} URLs -> ${sitemapPath}`);
+    await writeFile(sitemapPath, sitemapXml(sitemapPaths), "utf-8");
+    console.log(`Sitemap: ${sitemapPaths.length} URLs -> ${sitemapPath}`);
   },
 };
 


### PR DESCRIPTION
Closes #91.

## Why

The prerender migration (#89) fixed every route to return 200, but the pages spent months answering 404, so search engines have likely de-indexed everything except the homepage. A sitemap turns re-indexing from "whenever crawlers wander back" into "days after submission".

## What

- **`buildEnd` hook in `react-router.config.ts`**: after the build completes, walk `build/client` for the `index.html` files that were actually emitted and write `sitemap.xml` from them. Deriving from the real output means the sitemap cannot drift from the deployed pages - new projects/skills appear in it automatically on rebuild, same as the prerender set.
- URLs use the canonical trailing-slash form (GitHub Pages 301s the slash-less variant), `/404` is excluded, and the hook fails the build if it finds no routes (guards against silently shipping an empty sitemap).
- **`robots.txt`** gains `Sitemap: https://kyledarden.com/sitemap.xml`.

Implementation notes:
- Sharing the route list from `prerender()` via module state does not work - React Router instantiates the config module separately per hook, which produced an empty sitemap on the first attempt. Walking the output directory sidesteps the problem and is more truthful anyway.
- The config export changed from `satisfies Config` to an annotated `const`: with `buildEnd` present, declaration emit in the composite tsconfig rejects the inferred type (TS2742/TS4082).

## Verification

Local build emits valid XML with 38 URLs; spot-checked `/`, `/projects/`, a case-study route, and a skill route; `404` absent; built `robots.txt` carries the Sitemap line. Typecheck and lint green.

## After merge (manual)

Google Search Console: verify the `kyledarden.com` property, submit `sitemap.xml`, and request indexing for the key pages. Requires the site owner's Google account.