### PR TITLE
content: tidy skills data - dissolve Data Science & ML section, clean Movie Analytics ETL references

### DIFF
--- a/backend/src/main/java/com/kyledarden/backend/service/ProjectService.java
+++ b/backend/src/main/java/com/kyledarden/backend/service/ProjectService.java
@@ -330,7 +330,6 @@ public class ProjectService {
                             new Project.TechReference("dbt", 4),
                             new Project.TechReference("pandas", 5),
                             new Project.TechReference("numpy", 6),
-                            new Project.TechReference("jupyter", 9),
                             new Project.TechReference("docker", 10),
                             new Project.TechReference("git", 11),
                             new Project.TechReference("github-actions", 12)),

--- a/backend/src/main/java/com/kyledarden/backend/service/ProjectService.java
+++ b/backend/src/main/java/com/kyledarden/backend/service/ProjectService.java
@@ -330,9 +330,9 @@ public class ProjectService {
                             new Project.TechReference("dbt", 4),
                             new Project.TechReference("pandas", 5),
                             new Project.TechReference("numpy", 6),
-                            new Project.TechReference("docker", 10),
-                            new Project.TechReference("git", 11),
-                            new Project.TechReference("github-actions", 12)),
+                            new Project.TechReference("docker", 7),
+                            new Project.TechReference("git", 8),
+                            new Project.TechReference("github-actions", 9)),
 
                     /* challenges */
                     List.of(

--- a/backend/src/main/java/com/kyledarden/backend/service/TechService.java
+++ b/backend/src/main/java/com/kyledarden/backend/service/TechService.java
@@ -35,6 +35,11 @@ public class TechService {
                                         YearMonth.of(2023, 8),
                                         new ArrayList<>()),
 
+                        new TechItem("NumPy", "Data Engineering", "numpy",
+                                        "I use NumPy for efficient numerical computation and vectorized operations when transforming and analyzing datasets.",
+                                        YearMonth.of(2023, 8),
+                                        new ArrayList<>()),
+
                         new TechItem("BeautifulSoup", "Data Engineering", "beautifulsoup",
                                         "I use BeautifulSoup for web scraping and HTML parsing to extract structured data from web pages for ingestion pipelines and data collection projects.",
                                         YearMonth.of(2024, 1),
@@ -70,22 +75,6 @@ public class TechService {
                         new TechItem("Spring Boot", "Backend", "spring-boot",
                                         "Spring Boot runs this portfolio's intentionally lightweight Java 21 REST API, with test coverage and CI on every change.",
                                         YearMonth.of(2025, 8),
-                                        new ArrayList<>()),
-
-                        // ------------------ DATA SCIENCE & MACHINE LEARNING ------------------
-                        new TechItem("NumPy", "Data Science & Machine Learning", "numpy",
-                                        "I use NumPy for efficient numerical computation and vectorized operations when transforming and analyzing datasets.",
-                                        YearMonth.of(2023, 8),
-                                        new ArrayList<>()),
-
-                        new TechItem("scikit-learn", "Data Science & Machine Learning", "scikit-learn",
-                                        "I use scikit-learn to prototype regression, classification, and clustering models, applying training from my graduate data science and machine learning coursework.",
-                                        YearMonth.of(2023, 8),
-                                        new ArrayList<>()),
-
-                        new TechItem("Jupyter Notebook", "Data Science & Machine Learning", "jupyter",
-                                        "I use Jupyter Notebook for exploratory data analysis and for validating datasets during pipeline development.",
-                                        YearMonth.of(2023, 8),
                                         new ArrayList<>()),
 
                         // ------------------ FRONTEND ------------------
@@ -133,11 +122,6 @@ public class TechService {
                         new TechItem("Playwright", "DevOps & Tools", "playwright",
                                         "I use Playwright for real-browser automation in my QA work. It drives site-sentry's smoke, navigation, and UI checks against kyledarden.com on a twice-daily schedule.",
                                         YearMonth.of(2025, 10),
-                                        new ArrayList<>()),
-
-                        new TechItem("Postman", "DevOps & Tools", "postman",
-                                        "I use Postman to test, document, and automate RESTful API requests and workflows during backend and data service development.",
-                                        YearMonth.of(2024, 2),
                                         new ArrayList<>()));
 
         public List<TechItem> getAllTechItems() {

--- a/frontend/public/case-studies/movie-analytics-etl.md
+++ b/frontend/public/case-studies/movie-analytics-etl.md
@@ -35,7 +35,7 @@ The pipeline follows a **multi-layered architecture** built around dbt and Postg
   Referential integrity ensured across all dimension and fact tables.
 
 - **Analytics & Visualization:**  
-  Generated an **interactive HTML dashboard** using Python + Plotly, visualizing content trends, genre popularity, and rating distributions.
+  Generated an **interactive HTML dashboard** from a Python script, visualizing content trends, genre popularity, and rating distributions.
 
 ---
 
@@ -76,7 +76,7 @@ The pipeline follows a **multi-layered architecture** built around dbt and Postg
 
 **Languages & Tools:** Python, dbt, PostgreSQL, Docker Compose  
 **Testing & CI/CD:** dbt tests, GitHub Actions, pre-commit hooks  
-**Visualization:** Plotly, HTML Dashboards  
+**Visualization:** Python-generated interactive HTML dashboards  
 **Data Volume:** 176M+ records processed  
 **Design Methodology:** Kimball-style dimensional modeling
 


### PR DESCRIPTION
## Summary

Tidies the skills data for interview readability: removes skill entries no project backs up and dissolves the resulting empty Data Science & Machine Learning section, per #75 and #76. The Movie Analytics ETL project drops its unused `jupyter` tech reference, and its case study describes the dashboard without naming Plotly as a featured tool.

## Related Issue

Closes #75
Closes #76

## Scope

- `backend/.../service/ProjectService.java` - remove the `jupyter` tech reference from movie-analytics-etl.
- `backend/.../service/TechService.java` - remove Postman, scikit-learn, and Jupyter Notebook items; move NumPy to Data Engineering (placed after Pandas).
- `frontend/public/case-studies/movie-analytics-etl.md` - reword the two Plotly mentions to describe the Python-generated HTML dashboard generically.

## Out of Scope

- "Postman" mentions inside portfolio-website challenge narrative strings in `ProjectService.java` (prose/keyword lists, not tech references; #76 only covers the skills list).
- Education prose on About/Home mentioning data science coursework.

## Risk Level

Risk level: Low

Reason: Content-only data changes in backend services plus a static markdown reword. No route, schema, or component changes. The one structural risk (a dangling tech reference crashing `/api/projects`) was checked: the only references to removed slugs were the `jupyter` one removed here.

## Architecture Check

- [x] Controllers stay thin; services own the data.
- [x] Frontend keeps the API-types → mappers → domain-model layering; new fields added in all three layers.
- [x] No API route or response shape changes unless explicitly requested.
- [x] No changes to CORS config, deploy workflows, or secrets usage unless explicitly requested.
- [x] No analytics event names/parameters changed unless explicitly requested.
- [x] No new dependencies or build tooling changes unless explicitly requested.

## Documentation Check

Documentation: Updated

Reason: The case study reword is itself the documentation change (`movie-analytics-etl.md`). No command, endpoint, or architecture behavior changed, so README/CLAUDE.md/ADRs are unaffected.

## Verification

Commands run:

- `grep -rn -iE 'scikit|jupyter|postman|numpy|plotly|Data Science'` across backend, frontend, and docs to find every reference to affected items before and after the change.

Results:

- No remaining references to removed skill slugs; `numpy` resolves to the relocated Data Engineering item. Remaining Postman/data-science mentions are prose outside the skills data (listed in Out of Scope).
- Local Gradle build was not possible on this machine (no JDK installed); relying on CI's backend build and frontend lint/typecheck/build for compile verification.

## Review Notes

- The Skills page section disappearance is data-driven (grouping by category), so no frontend change was needed - worth a visual once-over on the deploy preview of `/skills`.
- NumPy's placement in Data Engineering (rather than removal) was a deliberate call: its documented use is vectorized transforms in the ETL pipeline, consistent with Pandas' categorization.
