### PR TITLE
test: establish baseline backend test coverage

### DIFF
--- a/backend/src/test/java/com/kyledarden/backend/config/CorsConfigTest.java
+++ b/backend/src/test/java/com/kyledarden/backend/config/CorsConfigTest.java
@@ -1,0 +1,69 @@
+package com.kyledarden.backend.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Pins the CORS policy in application.properties and CorsConfig: three
+ * allowed origins, GET/OPTIONS only. POST /api/contact is intentionally
+ * not callable cross-origin from the browser (see CLAUDE.md); if that
+ * policy changes deliberately, update these tests with it.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class CorsConfigTest {
+
+    private static final String PROD_ORIGIN = "https://kyledarden.com";
+    private static final String WWW_ORIGIN = "https://www.kyledarden.com";
+    private static final String DEV_ORIGIN = "http://localhost:5173";
+    private static final String EVIL_ORIGIN = "https://evil.example";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void allowedOriginsCanPreflightGet() throws Exception {
+        for (String origin : new String[] { PROD_ORIGIN, WWW_ORIGIN, DEV_ORIGIN }) {
+            mockMvc.perform(options("/api/projects")
+                    .header(HttpHeaders.ORIGIN, origin)
+                    .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET"))
+                    .andExpect(status().isOk())
+                    .andExpect(header().string(
+                            HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin));
+        }
+    }
+
+    @Test
+    void unknownOriginIsRejected() throws Exception {
+        mockMvc.perform(options("/api/projects")
+                .header(HttpHeaders.ORIGIN, EVIL_ORIGIN)
+                .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void crossOriginGetCarriesAllowOriginHeader() throws Exception {
+        mockMvc.perform(get("/api/health")
+                .header(HttpHeaders.ORIGIN, PROD_ORIGIN))
+                .andExpect(status().isOk())
+                .andExpect(header().string(
+                        HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, PROD_ORIGIN));
+    }
+
+    @Test
+    void preflightForPostIsRejectedEvenFromAllowedOrigin() throws Exception {
+        mockMvc.perform(options("/api/contact")
+                .header(HttpHeaders.ORIGIN, PROD_ORIGIN)
+                .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "POST"))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/backend/src/test/java/com/kyledarden/backend/controller/ContactControllerTest.java
+++ b/backend/src/test/java/com/kyledarden/backend/controller/ContactControllerTest.java
@@ -1,0 +1,70 @@
+package com.kyledarden.backend.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ContactControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private static final String VALID_BODY = """
+            {"name":"Ada Lovelace","email":"ada@example.com","message":"Hello!"}
+            """;
+
+    private org.springframework.test.web.servlet.RequestBuilder contactPost(String body) {
+        return post("/api/contact")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body);
+    }
+
+    @Test
+    void validSubmissionReturns202() throws Exception {
+        mockMvc.perform(contactPost(VALID_BODY))
+                .andExpect(status().isAccepted());
+    }
+
+    @Test
+    void blankNameReturns400() throws Exception {
+        mockMvc.perform(contactPost(
+                """
+                {"name":"","email":"ada@example.com","message":"Hello!"}
+                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void malformedEmailReturns400() throws Exception {
+        mockMvc.perform(contactPost(
+                """
+                {"name":"Ada","email":"not-an-email","message":"Hello!"}
+                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void missingMessageReturns400() throws Exception {
+        mockMvc.perform(contactPost(
+                """
+                {"name":"Ada","email":"ada@example.com"}
+                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void oversizedMessageReturns400() throws Exception {
+        String oversized = "x".repeat(5001);
+        mockMvc.perform(contactPost(
+                "{\"name\":\"Ada\",\"email\":\"ada@example.com\",\"message\":\"" + oversized + "\"}"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/backend/src/test/java/com/kyledarden/backend/controller/HealthControllerTest.java
+++ b/backend/src/test/java/com/kyledarden/backend/controller/HealthControllerTest.java
@@ -1,0 +1,26 @@
+package com.kyledarden.backend.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class HealthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void healthReturnsOkStatus() throws Exception {
+        mockMvc.perform(get("/api/health"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("ok"));
+    }
+}

--- a/backend/src/test/java/com/kyledarden/backend/controller/ProjectControllerTest.java
+++ b/backend/src/test/java/com/kyledarden/backend/controller/ProjectControllerTest.java
@@ -1,0 +1,40 @@
+package com.kyledarden.backend.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.blankOrNullString;
+import static org.hamcrest.Matchers.everyItem;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ProjectControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void projectsReturnsNonEmptyList() throws Exception {
+        mockMvc.perform(get("/api/projects"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(greaterThan(0))));
+    }
+
+    @Test
+    void everyProjectHasCoreDisplayFields() throws Exception {
+        mockMvc.perform(get("/api/projects"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[*].slug", everyItem(not(blankOrNullString()))))
+                .andExpect(jsonPath("$[*].title", everyItem(not(blankOrNullString()))))
+                .andExpect(jsonPath("$[*].summary", everyItem(not(blankOrNullString()))));
+    }
+}

--- a/backend/src/test/java/com/kyledarden/backend/controller/TechControllerTest.java
+++ b/backend/src/test/java/com/kyledarden/backend/controller/TechControllerTest.java
@@ -1,0 +1,55 @@
+package com.kyledarden.backend.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.blankOrNullString;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class TechControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void skillsReturnsNonEmptyList() throws Exception {
+        mockMvc.perform(get("/api/skills"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(greaterThan(0))));
+    }
+
+    @Test
+    void everySkillHasCoreDisplayFields() throws Exception {
+        mockMvc.perform(get("/api/skills"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[*].slug", everyItem(not(blankOrNullString()))))
+                .andExpect(jsonPath("$[*].name", everyItem(not(blankOrNullString()))))
+                .andExpect(jsonPath("$[*].category", everyItem(not(blankOrNullString()))))
+                .andExpect(jsonPath("$[*].description", everyItem(not(blankOrNullString()))));
+    }
+
+    @Test
+    void knownSkillSlugReturnsItemWithProjects() throws Exception {
+        mockMvc.perform(get("/api/skills/python"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.slug").value("python"))
+                .andExpect(jsonPath("$.projects", hasSize(greaterThan(0))));
+    }
+
+    @Test
+    void unknownSkillSlugReturns404() throws Exception {
+        mockMvc.perform(get("/api/skills/definitely-not-a-skill"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/backend/src/test/java/com/kyledarden/backend/service/ProjectTechReferenceIntegrityTest.java
+++ b/backend/src/test/java/com/kyledarden/backend/service/ProjectTechReferenceIntegrityTest.java
@@ -8,11 +8,14 @@ import org.springframework.boot.test.context.SpringBootTest;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**
- * Every project tech reference must resolve against TechService. A dangling
- * slug otherwise surfaces only at request time as a 500 on /api/projects,
- * which has nearly shipped before when removing skill entries.
+ * Every project tech reference must resolve against TechService.
+ * ProjectService resolves references lazily and throws on the first
+ * dangling slug (naming it in the exception message), so without this
+ * test a bad reference surfaces only at request time as a 500 on
+ * /api/projects - which has nearly shipped before when removing skills.
  */
 @SpringBootTest
 class ProjectTechReferenceIntegrityTest {
@@ -20,22 +23,12 @@ class ProjectTechReferenceIntegrityTest {
     @Autowired
     private ProjectService projectService;
 
-    @Autowired
-    private TechService techService;
-
     @Test
     void everyProjectTechReferenceResolvesToAKnownSkill() {
-        List<Project> projects = projectService.all();
+        List<Project> projects = assertDoesNotThrow(
+                projectService::all,
+                "A project references a tech slug missing from TechService;"
+                        + " the cause names the dangling slug");
         assertThat(projects).isNotEmpty();
-
-        for (Project project : projects) {
-            for (Project.TechItem tech : project.getTechStack()) {
-                assertThat(techService.getTechItemBySlug(tech.getId()))
-                        .withFailMessage(
-                                "Project '%s' references tech slug '%s', which does not exist in TechService",
-                                project.getSlug(), tech.getId())
-                        .isPresent();
-            }
-        }
     }
 }

--- a/backend/src/test/java/com/kyledarden/backend/service/ProjectTechReferenceIntegrityTest.java
+++ b/backend/src/test/java/com/kyledarden/backend/service/ProjectTechReferenceIntegrityTest.java
@@ -1,0 +1,41 @@
+package com.kyledarden.backend.service;
+
+import com.kyledarden.backend.model.Project;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Every project tech reference must resolve against TechService. A dangling
+ * slug otherwise surfaces only at request time as a 500 on /api/projects,
+ * which has nearly shipped before when removing skill entries.
+ */
+@SpringBootTest
+class ProjectTechReferenceIntegrityTest {
+
+    @Autowired
+    private ProjectService projectService;
+
+    @Autowired
+    private TechService techService;
+
+    @Test
+    void everyProjectTechReferenceResolvesToAKnownSkill() {
+        List<Project> projects = projectService.all();
+        assertThat(projects).isNotEmpty();
+
+        for (Project project : projects) {
+            for (Project.TechItem tech : project.getTechStack()) {
+                assertThat(techService.getTechItemBySlug(tech.getId()))
+                        .withFailMessage(
+                                "Project '%s' references tech slug '%s', which does not exist in TechService",
+                                project.getSlug(), tech.getId())
+                        .isPresent();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Establishes baseline backend test coverage so regressions in content and API behavior fail CI instead of surfacing in production. Until now the suite held only the default context-loads test - which is how the contact form shipped silently dropping every message (#90), and how a dangling tech reference could 500 `/api/projects` at request time (nearly hit while removing skills in #93).

## Related Issue

Closes #83

## Scope

17 new tests across 5 test classes, all under `backend/src/test`:

- `HealthControllerTest` - `/api/health` returns ok.
- `ProjectControllerTest` - `/api/projects` non-empty; every project carries slug/title/summary.
- `TechControllerTest` - `/api/skills` non-empty with core fields; known slug resolves with associated projects; unknown slug 404s.
- `ContactControllerTest` - valid POST returns 202; 400 for blank name, malformed email, missing message, and a 5001-char message.
- `ProjectTechReferenceIntegrityTest` - every project tech reference must resolve against `TechService`, failing with the project and slug named.
- `CorsConfigTest` - pins the current policy: three allowed origins, GET/OPTIONS only, unknown origins 403, and POST preflight rejected even from allowed origins (documented as intentional per CLAUDE.md).

## Out of Scope

- `/api/hello` (trivial dev endpoint, not in the issue scope).
- Any production-code changes; this PR is tests only.
- Frontend tests (no frontend test suite exists; separate discussion).

## Risk Level

Risk level: Low

Reason: Adds test files only; no production code touched. Worst case is a flaky test blocking CI, and all tests are deterministic MockMvc/service assertions with no network or timing dependence.

## Architecture Check

- [x] Controllers stay thin; services own the data.
- [x] Frontend keeps the API-types → mappers → domain-model layering; new fields added in all three layers.
- [x] No API route or response shape changes unless explicitly requested.
- [x] No changes to CORS config, deploy workflows, or secrets usage unless explicitly requested.
- [x] No analytics event names/parameters changed unless explicitly requested.
- [x] No new dependencies or build tooling changes unless explicitly requested.

## Documentation Check

Documentation: Update not needed

Reason: `./gradlew test` is already the documented test command in CLAUDE.md and README; no commands, endpoints, or behavior changed. The CORS test documents the GET/OPTIONS-only policy in code where it is most discoverable.

## Verification

Commands run:

- `./gradlew test` locally on Temurin 21 - all 18 tests pass (17 new + context-loads).
- Mutation check: temporarily pointed the movie-analytics-etl `numpy` reference at a bogus slug and re-ran `ProjectTechReferenceIntegrityTest` - it fails naming the project and slug, proving the integrity test is not vacuous. Reverted.

Results:

- BUILD SUCCESSFUL, 18/18 passing; mutation run FAILED as intended, then reverted cleanly.

## Review Notes

- `CorsConfigTest.preflightForPostIsRejectedEvenFromAllowedOrigin` intentionally pins the quirk that `POST /api/contact` is not callable cross-origin from the browser. If that policy is ever changed deliberately, this test is the tripwire that forces the change to be conscious.
- Test data (e.g. the `python` slug) references real content; if that skill were ever removed, `knownSkillSlugReturnsItemWithProjects` needs a new slug - acceptable coupling for a content-driven site.
