### PR TITLE
content: update FreightFolio status to paused across case study and overview

### DIFF
--- a/backend/src/main/java/com/kyledarden/backend/service/ProjectService.java
+++ b/backend/src/main/java/com/kyledarden/backend/service/ProjectService.java
@@ -172,7 +172,7 @@ public class ProjectService {
                     null,
 
                     /* overview */
-                    "Private, in-development SaaS backend designed for small freight carriers. It provides a modular system to streamline logistics operations through FastAPI services, focusing on load management, invoicing, and secure user authentication via AWS Cognito. Multi-tenant data isolation is designed and planned for an upcoming milestone. Not yet deployed; the source is private, with a public overview repo.",
+                    "Private SaaS backend designed for small freight carriers; active development is paused after the venture behind it ended before launch. It provides a modular system to streamline logistics operations through FastAPI services, focusing on load management, invoicing, and secure user authentication via AWS Cognito. Multi-tenant data isolation is designed but not yet enabled. Not deployed; the source is private, with a public overview repo.",
 
                     /* techStack - using references to TechService */
                     List.of(

--- a/frontend/public/case-studies/freightfolio.md
+++ b/frontend/public/case-studies/freightfolio.md
@@ -2,9 +2,9 @@
 
 ### Overview
 
-**FreightFolio** is a logistics SaaS platform built for small and mid-sized trucking carriers to **reduce reliance on spreadsheets** and **automate daily operational tasks** such as load tracking, invoicing, and payment reconciliation.
+**FreightFolio** was a logistics SaaS platform built for small and mid-sized trucking carriers to **reduce reliance on spreadsheets** and **automate daily operational tasks** such as load tracking, invoicing, and payment reconciliation.
 
-It’s an **in-development** backend system built from **modular FastAPI services** with **production-grade AWS Cognito authentication**, and a data model designed for planned multi-tenancy - similar to the kind of software powering real logistics and ERP platforms. The source is private; a public overview repo describes the system, and code walkthroughs are available on request.
+**Active development is paused; the venture behind it ended before launch in 2025.** The system is a backend built from **modular FastAPI services** with **production-grade AWS Cognito authentication**, and a data model designed for multi-tenancy - similar to the kind of software powering real logistics and ERP platforms. The source is private; a public overview repo describes the system, and code walkthroughs are available on request.
 
 ---
 
@@ -25,49 +25,53 @@ FreightFolio is composed of several independent services tied together through a
   Endpoints follow REST conventions with full OpenAPI documentation and Pydantic-based validation.
 
 - **Data Model & Persistence:**  
-  A **PostgreSQL** design with **per-service Alembic migrations** provides per-service schema separation and safe schema evolution today; tenant-scoped data isolation is designed and planned for an upcoming milestone.  
+  A **PostgreSQL** design with **per-service Alembic migrations** provides per-service schema separation and safe schema evolution today; tenant-scoped data isolation is designed but not yet enabled.  
   The ORM layer uses **SQLAlchemy 2.0** with typed models and foreign key constraints to preserve relational integrity.
 
 - **Domain Workflows:**  
   Load, invoice, and payment operations are handled as structured, validated API workflows across the services.  
-  Scheduled background automation (invoice generation, payment reminders, load status updates) is planned, mirroring the automation layer found in real TMS (Transportation Management Systems).
+  Scheduled background automation (invoice generation, payment reminders, load status updates) is scoped but not yet built, mirroring the automation layer found in real TMS (Transportation Management Systems).
 
 - **Authentication & Security:**  
   Implements **AWS Cognito**-based authentication (RS256 JWT verification with JWKS caching and key rotation), role-based permissions, and middleware for secure route access.
 
 - **CI/CD & Testing:**  
-  Uses **Pytest** for unit and integration testing, with **GitHub Actions** CI in progress.  
-  Each service includes Dockerfiles for consistent containerized builds; the system is not yet deployed to a cloud environment.
+  Uses **Pytest** for unit and integration testing; **GitHub Actions** CI remains incomplete.  
+  Each service includes Dockerfiles for consistent containerized builds; the system has not been deployed to a cloud environment.
 
 ---
 
 ### Technical Highlights
 
-- Designed the data model for **planned multi-tenancy**, with tenant-scoped isolation ready to enable when it lands on the roadmap.
+- Designed the data model for **multi-tenancy**, with tenant-scoped isolation designed but not yet enabled.
 - Engineered **per-service Alembic migrations**, ensuring modular and safe schema evolution.
 - Implemented **AWS Cognito authentication** and role-based access control for multi-user workflows.
-- Modeled **invoicing, payment tracking, and load management** as structured API workflows, with scheduled automation planned.
+- Modeled **invoicing, payment tracking, and load management** as structured API workflows, with scheduled automation planned but not yet built.
 - Employed structured logging and environment-based configuration in preparation for cloud deployment.
 
 ---
 
 ### Results
 
-- In-development backend simulating the operations of a logistics SaaS platform, with load, invoice, and auth services functional.
+- A functional backend covering the operations of a logistics SaaS platform, with load, invoice, and auth services working end to end locally.
 - Replaces spreadsheet workflows with **structured data models and API-driven workflows** for load management, invoice creation, and payment tracking.
 - Pytest unit and integration tests cover routes and services.
 - Modular architecture allows each domain (loads, invoices, payments) to evolve independently.
 - Documented with clear API specs and onboarding guides for future integration with a frontend or third-party dashboard.
-- Simple dashboard that displays some KPIs. This will be expanded on in later versions.
+- A simple KPI dashboard, built as the starting point for the planned analytics work.
 
 ---
 
-### Future Work
+### Remaining Roadmap
 
-- **Expand analytics dashboards** to visualize loads, revenue, and customer data.
-- **Integrate third-party APIs** (e.g., route optimization or carrier load boards).
-- **Introduce event-driven workflows** (e.g., via AWS Lambda or Celery for async automation).
-- **Refactor for serverless deployment** to demonstrate modern infrastructure design using AWS.
+Scoped but unbuilt - where the project picks up if I return to it:
+
+- **Expanded analytics dashboards** visualizing loads, revenue, and customer data.
+- **Third-party API integrations** (route optimization, carrier load boards).
+- **Event-driven workflows** (AWS Lambda or Celery for async automation).
+- **Cloud deployment** on AWS.
+
+The architecture, auth, and data-modeling work already carries forward into how I design backend systems.
 
 ---
 
@@ -76,8 +80,8 @@ FreightFolio is composed of several independent services tied together through a
 **Languages & Frameworks:** Python, FastAPI, SQLAlchemy, Alembic, Pydantic  
 **Auth:** AWS Cognito (with SES for transactional email)  
 **Database:** PostgreSQL  
-**Testing & CI/CD:** Pytest; GitHub Actions CI in progress  
-**Deployment:** Docker Compose locally; cloud deployment planned, not yet live
+**Testing & CI/CD:** Pytest; GitHub Actions CI incomplete  
+**Deployment:** Docker Compose locally; not deployed to the cloud
 
 ---
 


### PR DESCRIPTION
## Summary

Updates the FreightFolio case study and project overview to reflect the project's real status: the venture behind it ended before launch and active development is paused. The status is stated once up front; the rest of the content stays in neutral tense (designed but not yet enabled, scoped but not yet built) so the engineering substance reads on its own terms and the project can be picked back up without another rewrite.

## Related Issue

Closes #95

## Scope

- `frontend/public/case-studies/freightfolio.md` - status line in the Overview, neutral tense throughout, Future Work renamed to Remaining Roadmap with a "if I return to it" framing.
- `backend/.../service/ProjectService.java` - the freightfolio project overview text drops "in-development" and "upcoming milestone" for the paused framing.

## Out of Scope

- The freightfolio-overview repo README (updated separately in dardenkyle/freightfolio-overview#1).
- Any change to the project's tech stack, challenges, tags, or ordering.

## Risk Level

Risk level: Low

Reason: Content-only text changes; no routes, schemas, or references touched. Backend test suite passes.

## Architecture Check

- [x] Controllers stay thin; services own the data.
- [x] Frontend keeps the API-types → mappers → domain-model layering; new fields added in all three layers.
- [x] No API route or response shape changes unless explicitly requested.
- [x] No changes to CORS config, deploy workflows, or secrets usage unless explicitly requested.
- [x] No analytics event names/parameters changed unless explicitly requested.
- [x] No new dependencies or build tooling changes unless explicitly requested.

## Documentation Check

Documentation: Updated

Reason: The case study is the documentation; it is the file being corrected.

## Verification

Commands run:

- `./gradlew test` (backend suite from #94) against the ProjectService change.

Results:

- BUILD SUCCESSFUL, all tests pass, including the tech-reference integrity test over the edited project template.

## Review Notes

- After merge this needs the two-step deploy: Render auto-redeploys the backend, then re-run the frontend deploy workflow so prerendered pages pick up the new overview text (same sequence as #93).
