### PR TITLE
content: update home page hero copy

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -49,13 +49,13 @@ export default function Home({ loaderData: projects }: Route.ComponentProps) {
     <main className="max-w-6xl mx-auto px-6 py-12 space-y-14">
       {/* HERO */}
       <section className="mx-auto max-w-3xl text-center space-y-4">
-        <h1 className="text-4xl font-bold">Kyle Darden — Data Engineer</h1>
-        <p className="opacity-80">
-          Python • SQL • dbt • FastAPI • PostgreSQL • Docker
+        <h1 className="text-4xl font-bold">Kyle Darden</h1>
+        <p className="text-xl font-medium opacity-90">
+          Software Engineer — Data Platforms &amp; Pipelines
         </p>
         <p className="opacity-80">
-          I build data platforms end to end — ingestion, storage, and the APIs
-          that serve them, on a backend-engineering foundation.
+          I build data-intensive systems: ingestion pipelines, dimensional
+          models, and the APIs that serve them. Austin, TX.
         </p>
         <div className="flex items-center justify-center gap-3">
           <Button


### PR DESCRIPTION
## Summary

Tighten the homepage hero to the target copy from issue #100: the h1 carries only the name, followed by a single role line and one plain-language sentence about the work. The tool bullet list (Python, SQL, dbt, etc.) is removed from the hero; tool names remain on the Tech Stack section, Skills page, and project pages where they have context.

## Related Issue

Closes #100

## Scope

- `frontend/src/pages/Home.tsx` - hero section only: h1 text, new role line, replaced supporting sentence, removed tool list line.

## Out of Scope

- About teaser, project teasers, and Tech Stack sections on the homepage.
- Page meta/OG descriptions (already aligned with this positioning).
- A pre-existing mobile horizontal overflow caused by the navbar (reproduces on production at 390px width); worth a separate issue.

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Low

Reason: Copy-only change to one static section of one page; no logic, routing, data-flow, or styling-system changes.

## Architecture Check

- [x] Controllers stay thin; services own the data.
- [x] Frontend keeps the API-types → mappers → domain-model layering; new fields added in all three layers.
- [x] No API route or response shape changes unless explicitly requested.
- [x] No changes to CORS config, deploy workflows, or secrets usage unless explicitly requested.
- [x] No analytics event names/parameters changed unless explicitly requested.
- [x] No new dependencies or build tooling changes unless explicitly requested.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Update not needed

Reason: Page copy lives directly in `frontend/src/pages/*.tsx` per CLAUDE.md; no commands, content locations, architecture, or deployment behavior changed.

## Verification

Commands run:

- `npm run typecheck`
- `npm run lint`
- `npm run build` (prerender against the production API)
- Browser check of the prerendered/dev page at 1440x900 and 390x844.

Results:

- Typecheck, lint, and build all pass; prerendered `index.html` contains the new hero copy and no tool list.
- Hero bottom edge measures 357px of 900px viewport on desktop and 433px of 844px on mobile, so the full hero renders above the fold on both.

## Review Notes

- The role line uses the em dash exactly as specified in the issue's target copy.
- The role line is styled slightly larger (`text-xl font-medium`) than the supporting sentence to keep hierarchy under the smaller h1; flag if you want it plainer.
