### PR TITLE
content: link the site-sentry live dashboard from its project page

### DIFF
--- a/backend/src/main/java/com/kyledarden/backend/service/ProjectService.java
+++ b/backend/src/main/java/com/kyledarden/backend/service/ProjectService.java
@@ -372,14 +372,14 @@ public class ProjectService {
                     "Automated QA suite for kyledarden.com - Playwright + Pytest browser tests running twice daily via GitHub Actions, with HTML reports and Docker support.",
                     List.of("QA Automation", "Testing", "CI/CD", "Monitoring"),
                     "https://github.com/dardenkyle/site-sentry",
-                    null,
+                    "https://dardenkyle.github.io/site-sentry/",
                     50,
                     OffsetDateTime.parse("2025-10-15T00:00:00Z"),
                     null,
                     null,
 
                     /* overview */
-                    "site-sentry is an automated QA suite that continuously verifies kyledarden.com. Playwright drives real-browser smoke, navigation, and UI tests orchestrated with Pytest, and a scheduled GitHub Actions workflow runs the suite twice daily. Failures produce HTML reports with screenshots, and the suite runs locally or in Docker for consistent environments.",
+                    "site-sentry is an automated QA suite that continuously verifies kyledarden.com. Playwright drives real-browser smoke, navigation, and UI tests orchestrated with Pytest, and a scheduled GitHub Actions workflow runs the suite twice daily. Failures produce HTML reports with screenshots, and the suite runs locally or in Docker for consistent environments. A live dashboard publishes uptime and Navigation Timing trends collected from each scheduled run.",
 
                     /* techStack - using references to TechService */
                     List.of(


### PR DESCRIPTION
## Summary

The site-sentry dashboard at https://dardenkyle.github.io/site-sentry/ is live, but the project page linked only the GitHub repo. Set the project's `liveUrl` so the Links section on `/projects/site-sentry/` renders the dashboard link, and add one overview sentence describing what the dashboard publishes so the link has context.

## Related Issue

Closes #102

## Scope

- `backend/src/main/java/com/kyledarden/backend/service/ProjectService.java` - site-sentry template only: `liveUrl` set to the dashboard URL, one sentence appended to the overview.

## Out of Scope

- Frontend changes: the Links section already renders `liveUrl` when present (same path CS2 Analytics uses).
- The site-sentry case study markdown; the dashboard mention there can follow if wanted.
- `updatedAt` bump for the project; left as-is since this is a link addition, not a project-scope change.

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Low

Reason: Two-line content change to one project template; no schema, route, or logic changes. Note the backend is deployed separately, so this takes effect on the next backend deploy, not on merge.

## Architecture Check

- [x] Controllers stay thin; services own the data.
- [x] Frontend keeps the API-types → mappers → domain-model layering; new fields added in all three layers.
- [x] No API route or response shape changes unless explicitly requested.
- [x] No changes to CORS config, deploy workflows, or secrets usage unless explicitly requested.
- [x] No analytics event names/parameters changed unless explicitly requested.
- [x] No new dependencies or build tooling changes unless explicitly requested.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Update not needed

Reason: Project content lives in `ProjectService.java` per CLAUDE.md; no commands, content locations, architecture, or deployment behavior changed.

## Verification

Commands run:

- `./gradlew build` (includes tests)
- `curl -I https://dardenkyle.github.io/site-sentry/`

Results:

- Backend build and tests pass.
- Dashboard URL returns HTTP 200.

## Review Notes

- The overview sentence states the dashboard publishes uptime and Navigation Timing trends from scheduled runs, matching what the dashboard currently shows; flag if the wording overstates it.
