### PR TITLE
content: rework about page copy into a narrative arc

### DIFF
--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -1,14 +1,18 @@
 import { useEffect } from "react";
+import { Link } from "react-router";
 import { pageMeta } from "@/utils/meta";
 import type { Route } from "./+types/About";
 
 export function meta({ location }: Route.MetaArgs) {
   return pageMeta(
     "About — Kyle Darden",
-    "Data engineer working in Python, SQL, and dbt on a backend-engineering foundation of FastAPI, PostgreSQL, and Docker.",
+    "Software engineer building data-intensive systems — from a physics background to a live, end-to-end analytics platform and the projects around it.",
     { pathname: location.pathname }
   );
 }
+
+const caseStudyLink =
+  "underline underline-offset-4 decoration-white/30 hover:decoration-white/70 transition";
 
 export default function About() {
   // Scroll to top when component mounts
@@ -23,28 +27,43 @@ export default function About() {
         <section className="mx-auto max-w-3xl text-center space-y-4">
           <h1 className="text-4xl font-bold">About</h1>
           <p className="opacity-80">
-            I build data platforms end to end — ingestion, storage, and the
-            APIs that serve them, on a backend-engineering foundation.
+            I’m a software engineer building data-intensive systems — the
+            pipelines that ingest data, the models that structure it, and the
+            APIs that serve it. Based in Austin, TX.
           </p>
         </section>
         <div className="space-y-6 bg-neutral-900/30 border border-neutral-800/50 rounded-xl p-6 shadow-lg">
           <p className="opacity-80 max-w-6xl mx-auto">
-            I’m a data engineer working in Python, SQL, and dbt on a
-            backend-engineering foundation of FastAPI, PostgreSQL, and Docker.
-            My flagship project, CS2 Analytics, is live and public — a Python
-            ingestion pipeline feeding a PostgreSQL store, a FastAPI service,
-            and a React dashboard, deployed the whole way through.
+            I came to software from physics. What carried over is systems
+            thinking — understanding how the pieces of a system interact, and
+            working one layer below the problem when the surface answer
+            doesn’t hold.
           </p>
           <p className="opacity-80 max-w-6xl mx-auto">
-            I also build dimensional data warehouses — most recently a
-            star-schema warehouse over 176M+ IMDb records, with dbt staging and
-            marts layers backed by data-quality tests — and backend services
-            with production-grade AWS Cognito auth, Dockerized PostgreSQL, and
-            per-service migrations.
+            Most of that work happens in CS2 Analytics, which collects and
+            normalizes professional Counter-Strike 2 match data: a Python
+            ingestion pipeline into PostgreSQL, a FastAPI service, and a React
+            dashboard, deployed end to end and running in production. The
+            constraints have shaped it more than the initial build did — the
+            data source blocks datacenter IPs, so scraping is decoupled from
+            the cloud-hosted API, and ingestion tracks its own state so
+            interrupted runs resume cleanly instead of double-processing.
+            Details are in the{" "}
+            <Link
+              to="/projects/cs2-analytics/case-study/"
+              className={caseStudyLink}
+            >
+              case study
+            </Link>
+            .
           </p>
           <p className="opacity-80 max-w-6xl mx-auto">
-            I emphasize clear architecture, maintainable code, and thoughtful
-            trade-offs that ensure reliability at scale.
+            The rest of the work — and the case studies covering the
+            decisions behind it — is on the{" "}
+            <Link to="/projects/" className={caseStudyLink}>
+              projects page
+            </Link>
+            .
           </p>
           <p className="opacity-80 max-w-6xl mx-auto">
             I hold a B.S. in Physics from UT Austin (2022) and a postgraduate
@@ -53,15 +72,12 @@ export default function About() {
             enrolling in a graduate program.
           </p>
           <p className="opacity-80 max-w-6xl mx-auto">
-            I’m currently focused on data-engineering roles
-            (Python/SQL/dbt/AWS) — Austin or remote — where I can build
-            ingestion pipelines, warehouses, and the data-heavy APIs that
-            serve them.
+            I’m looking for software engineering roles — Austin or remote —
+            and I gravitate toward the data-heavy end of them: ingestion,
+            modeling, and the services that put data in front of people.
           </p>
           <p className="opacity-80 max-w-6xl mx-auto">
-            Outside of work, I enjoy competitive gaming, music, and weight
-            training — interests that keep me focused and creative in
-            engineering.
+            Outside of work: competitive gaming, music, and weight training.
           </p>
         </div>
       </section>


### PR DESCRIPTION
## Summary

Rework the About page from a resume restated in prose into a short narrative: a physics-to-systems-thinking opener, one concrete paragraph on CS2 Analytics and the production constraints that shaped it (linking its case study), and a single pointer to the projects page instead of a per-project roundup. The claimed-qualities paragraph is removed, the education line is kept, the looking-for line is broadened to software engineering roles, and the interests line loses its tacked-on justification. The intro and meta description now lead with the same role framing as the homepage hero.

During review the scope tightened beyond the issue text: the "one paragraph tying the remaining projects together" became a single pointer sentence to the projects page, keeping About focused on the person rather than duplicating the Projects surfaces.

## Related Issue

Closes #104

## Scope

- `frontend/src/pages/About.tsx` - meta description, intro copy, and body paragraphs; adds inline `Link`s to the CS2 case study and the projects page.

## Out of Scope

- Homepage About teaser copy (still the older phrasing; can follow in a separate issue if wanted).
- Project pages and case-study markdown.
- Any layout/styling-system changes; the section structure and card styling are untouched.

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Low

Reason: Copy change to one static page plus two internal links using existing routing; no data flow, logic, or styling-system changes.

## Architecture Check

- [x] Controllers stay thin; services own the data.
- [x] Frontend keeps the API-types → mappers → domain-model layering; new fields added in all three layers.
- [x] No API route or response shape changes unless explicitly requested.
- [x] No changes to CORS config, deploy workflows, or secrets usage unless explicitly requested.
- [x] No analytics event names/parameters changed unless explicitly requested.
- [x] No new dependencies or build tooling changes unless explicitly requested.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Update not needed

Reason: Page copy lives directly in `frontend/src/pages/*.tsx` per CLAUDE.md; no commands, content locations, architecture, or deployment behavior changed.

## Verification

Commands run:

- `npm run lint`
- `npm run typecheck`
- `npm run build` (prerender against the production API)
- Checked the prerendered `about/index.html` for the new meta description, copy, and link targets
- Browser check via `npm run dev` (desktop and narrow viewport)

Results:

- Lint, typecheck, and build all pass.
- Prerendered About page contains the new meta description and copy; case-study and projects-page links use trailing-slash internal URLs; old copy (claimed-qualities paragraph, tool-list phrasing) is gone.
- Acceptance criteria hold: role framing matches the hero in both intro and meta description, no unbacked quality claims, each tool name appears exactly once (CS2 paragraph only), and the body links to a case study.

## Review Notes

- Inline text links use a subtle underline treatment (`decoration-white/30`, brightening on hover); there was no existing inline-prose link idiom to reuse, so flag if you want them styled differently.
- The freightfolio project overview/case study still describe FreightFolio at the product level; per-project attribution wording was not touched here.
