### PR TITLE
seo: exclude individual skill pages from sitemap.xml

### DIFF
--- a/frontend/react-router.config.ts
+++ b/frontend/react-router.config.ts
@@ -98,8 +98,12 @@ const config: Config = {
     if (routePaths.length === 0) {
       throw new Error(`Sitemap: no prerendered routes found in ${clientDir}`);
     }
-    // /404 is the error page and must not be indexed
-    const sitemapPaths = routePaths.filter((p) => p !== "/404");
+    // /404 is the error page and must not be indexed. Per-skill pages
+    // stay prerendered and reachable from the skills index, but the
+    // sitemap advertises only the primary pages.
+    const sitemapPaths = routePaths.filter(
+      (p) => p !== "/404" && !p.startsWith("/skills/")
+    );
     const sitemapPath = path.join(clientDir, "sitemap.xml");
     await writeFile(sitemapPath, sitemapXml(sitemapPaths), "utf-8");
     console.log(`Sitemap: ${sitemapPaths.length} URLs -> ${sitemapPath}`);


### PR DESCRIPTION
## Summary

Exclude the individual `/skills/<slug>/` pages from `sitemap.xml` so it advertises only the primary pages. The filter sits next to the existing `/404` exclusion in `buildEnd`; the skills index (`/skills/`) remains listed, and the per-skill pages stay prerendered and reachable from it - this only changes what the sitemap offers crawlers.

On the issue's open question: no `noindex` robots tag was added. The skill pages are unique, canonical content still linked from the skills index; sitemap exclusion de-emphasizes them without asking crawlers to drop them from the index entirely. If they should be fully de-indexed later, that can be a follow-up.

## Related Issue

Closes #106

## Scope

- `frontend/react-router.config.ts` - `buildEnd` sitemap filter only.

## Out of Scope

- A `noindex` meta tag on skill pages (deliberately not added; see Summary).
- Prerender route list, page components, and meta tags - all unchanged.

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Low

Reason: Build-time filter on which URLs are written to sitemap.xml; no runtime code, routing, or page output changes.

## Architecture Check

- [x] Controllers stay thin; services own the data.
- [x] Frontend keeps the API-types → mappers → domain-model layering; new fields added in all three layers.
- [x] No API route or response shape changes unless explicitly requested.
- [x] No changes to CORS config, deploy workflows, or secrets usage unless explicitly requested.
- [x] No analytics event names/parameters changed unless explicitly requested.
- [x] No new dependencies or build tooling changes unless explicitly requested.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Update not needed

Reason: No commands, content locations, architecture boundaries, or deployment behavior changed; the sitemap emission location is unchanged.

## Verification

Commands run:

- `npm run lint`
- `npm run typecheck`
- `npm run build` (prerender against the production API)
- Inspected `build/client/sitemap.xml` and `build/client/skills/`

Results:

- Lint, typecheck, and build all pass.
- Sitemap went from 35 URLs to 14: home, `/about/`, `/contact/`, `/projects/`, five project pages, four case studies, and `/skills/`. No `/skills/<slug>/` URLs and no `/404`.
- Per-skill pages are still emitted to `build/client/skills/<slug>/` (still prerendered and reachable), confirming only the sitemap changed.

## Review Notes

- The filter matches `p.startsWith("/skills/")` against the slash-less internal route paths, so `/skills` itself never matches; trailing slashes are appended later by `canonicalUrl()`.
