### PR TITLE
fix: point manifest icons at favicon assets that exist

### DIFF
--- a/frontend/public/site.webmanifest
+++ b/frontend/public/site.webmanifest
@@ -2,8 +2,8 @@
   "name": "Kyle Darden — Portfolio",
   "short_name": "KD Portfolio",
   "icons": [
-    { "src": "favicon-192.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "favicon-512.png", "sizes": "512x512", "type": "image/png" }
+    { "src": "ann_favicon_16px.png", "sizes": "16x16", "type": "image/png" },
+    { "src": "ann_favicon_32px.png", "sizes": "32x32", "type": "image/png" }
   ],
   "theme_color": "#000000",
   "background_color": "#000000",


### PR DESCRIPTION
## Summary

`site.webmanifest` declared `favicon-192.png` and `favicon-512.png`, neither of which exists in `frontend/public/`, so anything fetching the manifest requested them and got 404s. This updates the `icons` entries to reference the assets that actually exist (`ann_favicon_16px.png`, `ann_favicon_32px.png`) with their true sizes.

Of the issue's two options, referencing the existing assets was chosen over generating 192/512 files: the only favicon artwork in the repo is 16px/32px anti-aliased PNGs, and upscaling those 6-16x produces a visibly blurry icon. Honest small sizes eliminate the 404s now; proper 192/512 icons need source artwork and can be a follow-up if PWA install surfaces ever matter for the site.

## Related Issue

Closes #99

## Scope

- `frontend/public/site.webmanifest` - the two `icons` entries only.

## Out of Scope

- Generating new 192/512 icon assets (no source artwork in the repo; see Summary).
- Favicon `<link>` tags in `root.tsx` (already correct, pointing at the 32px asset).

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Low

Reason: Static JSON asset change; no code, routing, or build behavior involved.

## Architecture Check

- [x] Controllers stay thin; services own the data.
- [x] Frontend keeps the API-types → mappers → domain-model layering; new fields added in all three layers.
- [x] No API route or response shape changes unless explicitly requested.
- [x] No changes to CORS config, deploy workflows, or secrets usage unless explicitly requested.
- [x] No analytics event names/parameters changed unless explicitly requested.
- [x] No new dependencies or build tooling changes unless explicitly requested.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Update not needed

Reason: Static asset fix; no commands, content locations, architecture, or deployment behavior changed.

## Verification

Commands run:

- `npm run build` (includes typecheck)
- Script check that every `icons[].src` in `build/client/site.webmanifest` resolves to a file in `build/client/`

Results:

- Build passes.
- Both manifest icon paths resolve in the build output; the previously-referenced `favicon-192.png`/`favicon-512.png` no longer appear anywhere, so no manifest-driven 404s remain.

## Review Notes

- If a crisp large icon is wanted later, the neural-network favicon would need to be redrawn as an SVG (or exported at high resolution from its original source) - worth a separate issue rather than shipping an upscale.
